### PR TITLE
Update Example with correct name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4.2.1
       
       - name: Run Security Scan and Comment Action
-        uses: dacoburn/security-tools@1.0.16
+        uses: dacoburn/security-wrapper@1.0.16
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The example still had the old tool name `security-tools` instead of `security-wrapper`.